### PR TITLE
Replaced lookup: Charset.forName('UTF-8') with JDK 7 constant

### DIFF
--- a/skeleton/grails-app/conf/logback.groovy
+++ b/skeleton/grails-app/conf/logback.groovy
@@ -3,7 +3,7 @@ import grails.util.Environment
 import org.springframework.boot.logging.logback.ColorConverter
 import org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter
 
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 conversionRule 'clr', ColorConverter
 conversionRule 'wex', WhitespaceThrowableProxyConverter
@@ -11,7 +11,7 @@ conversionRule 'wex', WhitespaceThrowableProxyConverter
 // See http://logback.qos.ch/manual/groovy.html for details on configuration
 appender('STDOUT', ConsoleAppender) {
     encoder(PatternLayoutEncoder) {
-        charset = Charset.forName('UTF-8')
+        charset = StandardCharsets.UTF_8
 
         pattern =
                 '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} ' + // Date
@@ -28,6 +28,7 @@ if (Environment.isDevelopmentMode() && targetDir != null) {
         file = "${targetDir}/stacktrace.log"
         append = true
         encoder(PatternLayoutEncoder) {
+            charset = StandardCharsets.UTF_8
             pattern = "%level %logger - %msg%n"
         }
     }


### PR DESCRIPTION
Replaced lookup: Charset.forName('UTF-8') with JDK 7 constant StandardCharsets.UTF_8 in both encode-closures.

In-order to simplify the example.