### PR TITLE
add mockito for compile time optimizations

### DIFF
--- a/profile.yml
+++ b/profile.yml
@@ -22,5 +22,7 @@ dependencies:
         - "org.grails:grails-core"
     testCompile:
         - "org.grails:grails-gorm-testing-support"
+        - "org.mockito:mockito-core"
+
     console:
         - "org.grails:grails-console"


### PR DESCRIPTION
https://github.com/grails/grails-testing-support/issues/44 - this mockito dependency speeds up integration tests due to its compile time processing optimizations