### PR TITLE
Fix for issue #22, 100 % CPU utilization

### DIFF
--- a/commands/run-app.groovy
+++ b/commands/run-app.groovy
@@ -90,6 +90,7 @@ try {
                 break
             }
         }
+        sleep(100);
     }
 
     if(!org.grails.cli.GrailsCli.isInteractiveModeActive()) {


### PR DESCRIPTION
1 CPU is fully used on the isServerAvailable() infinite loop when running certain Grails App using CLI. For example, Rundeck being executed from IntelliJ Idea.