### PR TITLE
bump up asset-pipeline to 3.0.7

### DIFF
--- a/features/asset-pipeline/feature.yml
+++ b/features/asset-pipeline/feature.yml
@@ -1,9 +1,9 @@
 description: Adds Asset Pipeline to a Grails project
 build:
     plugins:
-        - asset-pipeline
+        - com.bertramlabs.asset-pipeline
 dependencies:
     build:
-        - 'com.bertramlabs.plugins:asset-pipeline-gradle:2.15.1'
+        - 'com.bertramlabs.plugins:asset-pipeline-gradle:3.0.7'
     runtime:
-        - "com.bertramlabs.plugins:asset-pipeline-grails:2.15.1"
+        - "com.bertramlabs.plugins:asset-pipeline-grails:3.0.7"


### PR DESCRIPTION
3.0.x branch of asset pipeline is only JDK 1.8 compatible