### PR TITLE
Set ignoreExitValue to true for the gradle skeleton

### DIFF
--- a/skeleton/build.gradle
+++ b/skeleton/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 }
 
 bootRun {
+    ignoreExitValue true
     jvmArgs(
         '-Dspring.output.ansi.enabled=always', 
         '-noverify', 


### PR DESCRIPTION
When run-app and stop-app are used they invoke bootRun which
when it ends throws an error due to a non-zero exit code.
This is misleading and can therefore be ignored when using grails