### PR TITLE
Bump webdriver-binaries-gradle-plugin from 2.2 to 2.4

### DIFF
--- a/features/geb2/feature.yml
+++ b/features/geb2/feature.yml
@@ -4,7 +4,7 @@ build:
         - com.github.erdi.webdriver-binaries
 dependencies:
     - scope: build
-      coords: gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:2.2
+      coords: gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:2.4
     - scope: testCompile
       coords: org.grails.plugins:geb
     - scope: testCompile


### PR DESCRIPTION
Signed-off-by: Puneet Behl <behlp@objectcomputing.com>