### PR TITLE
Bump Hibernate Core from 5.4.18.Final to 5.5.32.Final

### DIFF
--- a/features/hibernate5/feature.yml
+++ b/features/hibernate5/feature.yml
@@ -5,7 +5,7 @@ dependencies:
     - scope: compile
       coords: "org.grails.plugins:hibernate5"
     - scope: compile
-      coords: "org.hibernate:hibernate-core:5.4.18.Final"
+      coords: "org.hibernate:hibernate-core:5.4.32.Final"
     - scope: runtime
       coords: 'org.glassfish.web:el-impl:2.1.2-b03'
     - scope: runtime


### PR DESCRIPTION
Signed-off-by: Puneet Behl <behlp@objectcomputing.com>