### PR TITLE
Clean feature/mongodb/gradle.properties

### DIFF
--- a/features/maven-central-publish/feature.yml
+++ b/features/maven-central-publish/feature.yml
@@ -1,1 +1,0 @@
-description: Publish Artifacts to Maven Central

--- a/features/mongodb/skeleton/gradle.properties
+++ b/features/mongodb/skeleton/gradle.properties
@@ -1,8 +1,1 @@
-grailsVersion=@grails.version@
-groovyVersion=@groovy.version@
-gorm.version=@gorm.version@
-org.gradle.daemon=true
-org.gradle.parallel=true
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1024M
 embedded-mongo.version=2.2.0
-mongodbJavaDriverVersion=4.0.3


### PR DESCRIPTION
Remove redundant properties from the feature/mongodb because instead of replacing we are now merging skeleton/gradle.properties with feature/featurename/gradle.properties.