### PR TITLE
Add settings.gradle in the project skeleton 

### DIFF
--- a/skeleton/settings.gradle
+++ b/skeleton/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = '@info.app.name@'


### PR DESCRIPTION
Starting Gradle 7, executing Gradle build without settings.gradle file will result in error. See https://docs.gradle.org/current/userguide/upgrading_version_6.html#executing_a_gradle_build_without_a_settings_file_is_now_an_error