### PR TITLE
Make the wrapper scripts keep correct EOL

### DIFF
--- a/skeleton/.gitattributes
+++ b/skeleton/.gitattributes
@@ -1,0 +1,4 @@
+gradlew             text eol=lf
+gradlew.bat         text eol=crlf
+grailsw             text eol=lf
+grailsw.bat         text eol=crlf


### PR DESCRIPTION
* Enabled EOL control for the Gradle/Grails wrappers only.
* https://www.git-scm.com/docs/gitattributes