### PR TITLE
Adding fallbackTo32Bit option to the chromedriver webdriver settings …

### DIFF
--- a/features/geb2/skeleton/build.gradle
+++ b/features/geb2/skeleton/build.gradle
@@ -1,5 +1,8 @@
 webdriverBinaries {
-    chromedriver '2.45.0'
+    chromedriver {
+        version = '2.45.0'
+        fallbackTo32Bit = true
+    }
     geckodriver '0.30.0'
 }
 


### PR DESCRIPTION
…as there is no 64-bit driver for windows.