### PR TITLE
Update default repositories

### DIFF
--- a/profile.yml
+++ b/profile.yml
@@ -6,6 +6,7 @@ repositories:
     - "https://repo.grails.org/grails/core"
 build:
     repositories:
+        - "https://plugins.gradle.org/m2/"
         - "https://repo.grails.org/grails/core"
     plugins:
         - eclipse

--- a/skeleton/build.gradle
+++ b/skeleton/build.gradle
@@ -13,6 +13,7 @@ group "@grails.app.group@"
 @buildPlugins@
 
 repositories {
+    mavenCentral()
 @repositories@
 }
 


### PR DESCRIPTION
Fixes grails/grails-core#12739

- Add mavenCentral under repositories
- Add Gradle Plugin repo under build repositories